### PR TITLE
URL escaping and SETTINGS: section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ module.exports = {
     new AppCachePlugin({
       cache: ['someOtherAsset.jpg'],
       network: null,  // No network access allowed!
-      fallback: ['failwhale.jpg']
+      fallback: ['failwhale.jpg'],
+      settings: ['prefer-online']
     })
   ]
 }
@@ -23,6 +24,7 @@ Arguments:
 * `network`: An array of assets that may be accessed via the network.
   Defaults to `['*']`.
 * `fallback`: An array of fallback assets.
+* `settings`: An array of settings.
 
 ## License
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,7 +1,7 @@
 class AppCachePlugin
 
   @AppCache = class AppCache
-    constructor: (@cache, @network, @fallback, @hash) -> @assets = []
+    constructor: (@cache, @network, @fallback, @settings, @hash) -> @assets = []
 
     addAsset: (asset) -> @assets.push encodeURI(asset)
 
@@ -13,6 +13,9 @@ class AppCachePlugin
         if @cache?.length then "CACHE:\n#{@cache.join '\n'}\n"
         if @network?.length then "NETWORK:\n#{@network.join '\n'}\n"
         if @fallback?.length then "FALLBACK:\n#{@fallback.join '\n'}\n"
+        if @settings then "SETTINGS:\n#{
+          if @settings.preferOnline then 'prefer-online\n' else ''
+        }"
       ].filter((v) -> v?.length).join '\n'
 
     source: ->
@@ -27,10 +30,11 @@ class AppCachePlugin
     @cache = options?.cache
     @network = options?.network or ['*']
     @fallback = options?.fallback
+    @settings = options?.settings
 
   apply: (compiler) ->
     compiler.plugin 'emit', (compilation, callback) =>
-      appCache = new AppCache @cache, @network, @fallback, compilation.hash
+      appCache = new AppCache @cache, @network, @fallback, @settings, compilation.hash
       appCache.addAsset key for key in Object.keys compilation.assets
       compilation.assets['manifest.appcache'] = appCache
       callback()

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -3,7 +3,7 @@ class AppCachePlugin
   @AppCache = class AppCache
     constructor: (@cache, @network, @fallback, @hash) -> @assets = []
 
-    addAsset: (asset) -> @assets.push asset
+    addAsset: (asset) -> @assets.push encodeURI(asset)
 
     size: -> Buffer.byteLength @source(), 'utf8'
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -13,9 +13,7 @@ class AppCachePlugin
         if @cache?.length then "CACHE:\n#{@cache.join '\n'}\n"
         if @network?.length then "NETWORK:\n#{@network.join '\n'}\n"
         if @fallback?.length then "FALLBACK:\n#{@fallback.join '\n'}\n"
-        if @settings then "SETTINGS:\n#{
-          if @settings.preferOnline then 'prefer-online\n' else ''
-        }"
+        if @settings?.length then "SETTINGS:\n#{@settings.join '\n'}\n"
       ].filter((v) -> v?.length).join '\n'
 
     source: ->

--- a/test/tests.coffee
+++ b/test/tests.coffee
@@ -9,6 +9,7 @@ describe 'AppCache', ->
         ['cache.test']
         ['network.test']
         ['fallback.test']
+        undefined
         createHash('md5').digest 'hex'
       )
 
@@ -78,6 +79,38 @@ describe 'AppCache', ->
 
         """
 
+    it 'should include SETTINGS section', ->
+      @appCache.settings = ["prefer-online"]
+      assert.equal @appCache.getManifestBody(),
+        """
+        CACHE:
+        cache.test
+
+        NETWORK:
+        network.test
+
+        FALLBACK:
+        fallback.test
+
+        SETTINGS:
+        prefer-online
+
+        """
+
+    it 'should exclude empty SETTINGS section', ->
+      @appCache.settings = {}
+      assert.equal @appCache.getManifestBody(),
+        """
+        CACHE:
+        cache.test
+
+        NETWORK:
+        network.test
+
+        FALLBACK:
+        fallback.test
+
+        """
 
   describe 'source()', ->
     it 'should include webpack build hash', ->


### PR DESCRIPTION
Hi Eric,

I needed two new things in the appcache-webpack-plugin:
- Asset URIs need to be escaped.  (Otherwise browsers cannot cope with blanks in URIs.)
- Creating a "SETTINGS:" section as described in recent versions of the spec.

Since this might be helpful for others too, you might want to pull these changes into the "official" appcache-webpack-plugin repository.

Regards,
Heribert.
