### PR TITLE
use-options-output-publicPath

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -31,7 +31,7 @@ class AppCachePlugin
   apply: (compiler) ->
     compiler.plugin 'emit', (compilation, callback) =>
       appCache = new AppCache @cache, @network, @fallback, compilation.hash
-      appCache.addAsset key for key in Object.keys compilation.assets
+      appCache.addAsset (compiler.options.output.publicPath + key) for key in Object.keys compilation.assets
       compilation.assets['manifest.appcache'] = appCache
       callback()
 


### PR DESCRIPTION
IMO, It makes sense to use the `compiler.options.output.publicPath` when generating file's path. What do you think ?
