### PR TITLE
Use concatenation instead of path.join for URLs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-import path from 'path';
-
 class AppCache {
 
   constructor(cache, network, fallback, settings, hash) {
@@ -72,7 +70,7 @@ export default class AppCachePlugin {
       const appCache = new AppCache(this.cache, this.network, this.fallback, this.settings, compilation.hash);
       Object.keys(compilation.assets)
         .filter(asset => !this.exclude.some(pattern => pattern.test(asset)))
-        .forEach(asset => appCache.addAsset(path.join(publicPath, asset)));
+        .forEach(asset => appCache.addAsset(publicPath + asset));
       compilation.assets[this.output] = appCache;
       callback();
     });


### PR DESCRIPTION
When using this plugin on Windows, it currently always includes a `%5C` at the start of every URL in the manifest when `publicPath` is `/`. This obviously makes the appcache fail to load the specified assets.

This change fixes this issue by concatenating the `publicPath` and the asset URL instead of using `path.join`. Webpack (in its documentation) seems to expect a trailing slash on the `publicPath`. `path.join` is for file paths, not URLs since it uses the OS's path separator.
