### PR TITLE
Use path.join instead of string concatenation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import path from 'path'
+
 class AppCache {
 
   constructor(cache, network, fallback, settings, hash, comment) {
@@ -73,7 +75,7 @@ export default class AppCachePlugin {
       const appCache = new AppCache(this.cache, this.network, this.fallback, this.settings, compilation.hash, this.comment);
       Object.keys(compilation.assets)
         .filter(asset => !this.exclude.some(pattern => pattern.test(asset)))
-        .forEach(asset => appCache.addAsset(publicPath + asset));
+        .forEach(asset => appCache.addAsset(path.join(publicPath, asset)));
       compilation.assets[this.output] = appCache;
       callback();
     });


### PR DESCRIPTION
Fixes two bugs.
1. If public path doesn't end with a slash
2. If asset path starts with `.` or `../`
