### PR TITLE
Support webpack 4.0 tapable api

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,12 +69,22 @@ export default class AppCachePlugin {
     const {options: {output: outputOptions = {}} = {}} = compiler;
     const {publicPath = ''} = outputOptions;
 
-		compiler.hooks.emit.tap("appacache-webpack-plugin", (compilation) => {
+		const buildAppCache = (compilation) => {
       const appCache = new AppCache(this.cache, this.network, this.fallback, this.settings, compilation.hash, this.comment);
       Object.keys(compilation.assets)
         .filter(asset => !this.exclude.some(pattern => pattern.test(asset)))
         .forEach(asset => appCache.addAsset(publicPath + asset));
       compilation.assets[this.output] = appCache;
-    });
+		}
+
+		// Detect Webpack 4 API.
+		if (compiler.hooks && compiler.hooks.emit && compiler.hooks.emit.tap) {
+			compiler.hooks.emit.tap('AppCachePlugin', buildAppCache);
+		} else {
+			compiler.plugin('emit', (compilation, callback) => {
+				buildAppCache()
+				callback()
+			})
+		}
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -69,13 +69,12 @@ export default class AppCachePlugin {
     const {options: {output: outputOptions = {}} = {}} = compiler;
     const {publicPath = ''} = outputOptions;
 
-    compiler.plugin('emit', (compilation, callback) => {
+		compiler.hooks.emit.tap("appacache-webpack-plugin", (compilation) => {
       const appCache = new AppCache(this.cache, this.network, this.fallback, this.settings, compilation.hash, this.comment);
       Object.keys(compilation.assets)
         .filter(asset => !this.exclude.some(pattern => pattern.test(asset)))
         .forEach(asset => appCache.addAsset(publicPath + asset));
       compilation.assets[this.output] = appCache;
-      callback();
     });
   }
 }


### PR DESCRIPTION
Fix the deprecation warning for webpack 4.0 https://github.com/lettertwo/appcache-webpack-plugin/issues/23